### PR TITLE
feat: Byte slice from buffer helper function

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,0 +1,23 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Tag Replacer
+        uses: AlexRogalskiy/github-action-tag-replacer@v2.0.1
+        with:
+          sourceFile: './internal/version/version.go',
+          prefix: 'const (\n	Version = "'
+          suffix: '"\n)'
+          placeholder: 'const \\(\n	Version = "(.*)"\n\\)'
+          replacement: ${{github.ref_name}}
+      - name: push
+        uses: actions-x/commit@v6

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Tag Replacer
         uses: AlexRogalskiy/github-action-tag-replacer@v2.0.1
         with:
-          sourceFile: './internal/version/version.go',
+          sourceFile: './internal/version/version.go'
           prefix: 'const (\n	Version = "'
           suffix: '"\n)'
           placeholder: 'const \\(\n	Version = "(.*)"\n\\)'

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Tag Replacer
         uses: AlexRogalskiy/github-action-tag-replacer@v2.0.1
         with:
-          sourceFile: './internal/version/version.go'
+          sourceFile: "./internal/version/version.go"
           prefix: 'const (\n	Version = "'
           suffix: '"\n)'
           placeholder: 'const \\(\n	Version = "(.*)"\n\\)'

--- a/buffer.go
+++ b/buffer.go
@@ -43,3 +43,7 @@ func NewBuffer() *Buffer {
 func (buf *Buffer) Bytes() []byte {
 	return *buf
 }
+
+func (buf *Buffer) Len() int {
+	return len(*buf)
+}

--- a/buffer.go
+++ b/buffer.go
@@ -39,3 +39,7 @@ func NewBuffer() *Buffer {
 	c := make(Buffer, 0, defaultSize)
 	return &c
 }
+
+func (buf *Buffer) Bytes() []byte {
+	return *buf
+}

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -133,7 +133,7 @@ func TestChain(t *testing.T) {
 	var err error
 	var remaining []byte
 
-	remaining, val.err, err = decodeError(*p)
+	remaining, val.err, err = decodeError(p.Bytes())
 	assert.NoError(t, err)
 	assert.ErrorIs(t, val.err, test.err)
 
@@ -229,7 +229,7 @@ func TestChain(t *testing.T) {
 		encodeUint64(p, test.num4)
 		encodeBool(p, test.truth)
 		encodeNil(p)
-		remaining, val.err, err = decodeError(*p)
+		remaining, val.err, err = decodeError(p.Bytes())
 		remaining, val.test, err = decodeString(remaining)
 		remaining, val.b, err = decodeBytes(remaining, val.b)
 		remaining, val.num1, err = decodeUint8(remaining)
@@ -286,7 +286,7 @@ func TestCompleteChain(t *testing.T) {
 	val := new(testStruct)
 	var err error
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 
 	val.err, err = d.Error()
 	assert.NoError(t, err)
@@ -375,7 +375,7 @@ func TestCompleteChain(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Error(test.err).String(test.test).Bytes(test.b).Uint8(test.num1).Uint16(test.num2).Uint32(test.num3).Uint64(test.num4).Bool(test.truth).Nil()
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		val.err, err = d.Error()
 		val.test, err = d.String()
 		val.b, err = d.Bytes(val.b)
@@ -396,7 +396,7 @@ func TestNilSlice(t *testing.T) {
 	p := NewBuffer()
 	Encoder(p).Slice(uint32(len(s)), StringKind)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	j, err := d.Slice(StringKind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(len(s)), j)
@@ -414,7 +414,7 @@ func TestError(t *testing.T) {
 	p := NewBuffer()
 	Encoder(p).Error(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	_, err := d.String()
 	assert.ErrorIs(t, err, InvalidString)
 

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -424,3 +424,12 @@ func TestError(t *testing.T) {
 
 	d.Return()
 }
+
+func TestLen(t *testing.T) {
+	t.Parallel()
+
+	p := NewBuffer()
+	Encoder(p).String("Hello World")
+
+	assert.Equal(t, 17, p.Len())
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -30,24 +30,24 @@ func TestDecodeNil(t *testing.T) {
 
 	var value bool
 
-	remaining, value := decodeNil(*p)
+	remaining, value := decodeNil(p.Bytes())
 	assert.True(t, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, value = decodeNil((*p)[1:])
+	_, value = decodeNil((p.Bytes())[1:])
 	assert.False(t, value)
 
-	remaining, value = decodeNil(*p)
+	remaining, value = decodeNil(p.Bytes())
 	assert.True(t, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.True(t, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeNil(p)
-		_, _ = decodeNil(*p)
+		_, _ = decodeNil(p.Bytes())
 		p.Reset()
 	})
 	assert.Zero(t, n)
@@ -59,18 +59,18 @@ func TestDecodeMap(t *testing.T) {
 	p := NewBuffer()
 	encodeMap(p, 32, StringKind, Uint32Kind)
 
-	remaining, size, err := decodeMap(*p, StringKind, Uint32Kind)
+	remaining, size, err := decodeMap(p.Bytes(), StringKind, Uint32Kind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(32), size)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeMap((*p)[1:], StringKind, Uint32Kind)
+	_, _, err = decodeMap((p.Bytes())[1:], StringKind, Uint32Kind)
 	assert.ErrorIs(t, err, InvalidMap)
 
-	_, _, err = decodeMap(*p, StringKind, Float64Kind)
+	_, _, err = decodeMap(p.Bytes(), StringKind, Float64Kind)
 	assert.ErrorIs(t, err, InvalidMap)
 
-	remaining, size, err = decodeMap(*p, StringKind, Uint32Kind)
+	remaining, size, err = decodeMap(p.Bytes(), StringKind, Uint32Kind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(32), size)
 	assert.Equal(t, 0, len(remaining))
@@ -78,7 +78,7 @@ func TestDecodeMap(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeNil(p)
-		remaining, size, err = decodeMap(*p, StringKind, Uint32Kind)
+		remaining, size, err = decodeMap(p.Bytes(), StringKind, Uint32Kind)
 		p.Reset()
 	})
 	assert.Zero(t, n)
@@ -93,33 +93,33 @@ func TestDecodeBytes(t *testing.T) {
 
 	var value []byte
 
-	remaining, value, err := decodeBytes(*p, value)
+	remaining, value, err := decodeBytes(p.Bytes(), value)
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, value, err = decodeBytes((*p)[1:], value)
+	_, value, err = decodeBytes((p.Bytes())[1:], value)
 	assert.ErrorIs(t, err, InvalidBytes)
 
-	remaining, value, err = decodeBytes(*p, value)
+	remaining, value, err = decodeBytes(p.Bytes(), value)
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.Equal(t, v, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeBytes(p, v)
-		remaining, value, err = decodeBytes(*p, value)
+		remaining, value, err = decodeBytes(p.Bytes(), value)
 		p.Reset()
 	})
 	assert.Zero(t, n)
 
 	n = testing.AllocsPerRun(100, func() {
 		encodeBytes(p, v)
-		remaining, value, err = decodeBytes(*p, nil)
+		remaining, value, err = decodeBytes(p.Bytes(), nil)
 		p.Reset()
 	})
 	assert.Equal(t, float64(1), n)
@@ -131,7 +131,7 @@ func TestDecodeBytes(t *testing.T) {
 	}
 	var size uint32
 
-	remaining, size, err = decodeSlice(*p, BytesKind)
+	remaining, size, err = decodeSlice(p.Bytes(), BytesKind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(len(s)), size)
 
@@ -156,26 +156,26 @@ func TestDecodeString(t *testing.T) {
 
 	var value string
 
-	remaining, value, err := decodeString(*p)
+	remaining, value, err := decodeString(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeString((*p)[1:])
+	_, _, err = decodeString((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidString)
 
-	remaining, value, err = decodeString(*p)
+	remaining, value, err = decodeString(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.Equal(t, v, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeString(p, v)
-		remaining, value, err = decodeString(*p)
+		remaining, value, err = decodeString(p.Bytes())
 		p.Reset()
 	})
 	assert.Equal(t, float64(1), n)
@@ -187,7 +187,7 @@ func TestDecodeString(t *testing.T) {
 	}
 	var size uint32
 
-	remaining, size, err = decodeSlice(*p, StringKind)
+	remaining, size, err = decodeSlice(p.Bytes(), StringKind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(len(s)), size)
 
@@ -212,26 +212,26 @@ func TestDecodeError(t *testing.T) {
 
 	var value error
 
-	remaining, value, err := decodeError(*p)
+	remaining, value, err := decodeError(p.Bytes())
 	assert.NoError(t, err)
 	assert.ErrorIs(t, value, v)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeError((*p)[1:])
+	_, _, err = decodeError((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidError)
 
-	remaining, value, err = decodeError(*p)
+	remaining, value, err = decodeError(p.Bytes())
 	assert.NoError(t, err)
 	assert.ErrorIs(t, value, v)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.ErrorIs(t, value, v)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeError(p, v)
-		remaining, value, err = decodeError(*p)
+		remaining, value, err = decodeError(p.Bytes())
 		p.Reset()
 	})
 	assert.Equal(t, float64(2), n)
@@ -243,7 +243,7 @@ func TestDecodeError(t *testing.T) {
 	}
 	var size uint32
 
-	remaining, size, err = decodeSlice(*p, ErrorKind)
+	remaining, size, err = decodeSlice(p.Bytes(), ErrorKind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(len(s)), size)
 
@@ -266,26 +266,26 @@ func TestDecodeBool(t *testing.T) {
 
 	var value bool
 
-	remaining, value, err := decodeBool(*p)
+	remaining, value, err := decodeBool(p.Bytes())
 	assert.NoError(t, err)
 	assert.True(t, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeBool((*p)[1:])
+	_, _, err = decodeBool((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidBool)
 
-	remaining, value, err = decodeBool(*p)
+	remaining, value, err = decodeBool(p.Bytes())
 	assert.NoError(t, err)
 	assert.True(t, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.True(t, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeBool(p, true)
-		remaining, value, err = decodeBool(*p)
+		remaining, value, err = decodeBool(p.Bytes())
 		p.Reset()
 	})
 	assert.Zero(t, n)
@@ -297,7 +297,7 @@ func TestDecodeBool(t *testing.T) {
 	}
 	var size uint32
 
-	remaining, size, err = decodeSlice(*p, BoolKind)
+	remaining, size, err = decodeSlice(p.Bytes(), BoolKind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(len(s)), size)
 
@@ -322,26 +322,26 @@ func TestDecodeUint8(t *testing.T) {
 
 	var value uint8
 
-	remaining, value, err := decodeUint8(*p)
+	remaining, value, err := decodeUint8(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeUint8((*p)[1:])
+	_, _, err = decodeUint8((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidUint8)
 
-	remaining, value, err = decodeUint8(*p)
+	remaining, value, err = decodeUint8(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.Equal(t, v, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeUint8(p, v)
-		remaining, value, err = decodeUint8(*p)
+		remaining, value, err = decodeUint8(p.Bytes())
 		p.Reset()
 	})
 	assert.Zero(t, n)
@@ -356,26 +356,26 @@ func TestDecodeUint16(t *testing.T) {
 
 	var value uint16
 
-	remaining, value, err := decodeUint16(*p)
+	remaining, value, err := decodeUint16(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeUint16((*p)[1:])
+	_, _, err = decodeUint16((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidUint16)
 
-	remaining, value, err = decodeUint16(*p)
+	remaining, value, err = decodeUint16(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.Equal(t, v, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeUint16(p, v)
-		remaining, value, err = decodeUint16(*p)
+		remaining, value, err = decodeUint16(p.Bytes())
 		p.Reset()
 	})
 	assert.Zero(t, n)
@@ -390,26 +390,26 @@ func TestDecodeUint32(t *testing.T) {
 
 	var value uint32
 
-	remaining, value, err := decodeUint32(*p)
+	remaining, value, err := decodeUint32(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeUint32((*p)[1:])
+	_, _, err = decodeUint32((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidUint32)
 
-	remaining, value, err = decodeUint32(*p)
+	remaining, value, err = decodeUint32(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.Equal(t, v, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeUint32(p, v)
-		remaining, value, err = decodeUint32(*p)
+		remaining, value, err = decodeUint32(p.Bytes())
 		p.Reset()
 	})
 	assert.Zero(t, n)
@@ -425,26 +425,26 @@ func TestDecodeUint64(t *testing.T) {
 
 	var value uint64
 
-	remaining, value, err := decodeUint64(*p)
+	remaining, value, err := decodeUint64(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeUint64((*p)[1:])
+	_, _, err = decodeUint64((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidUint64)
 
-	remaining, value, err = decodeUint64(*p)
+	remaining, value, err = decodeUint64(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.Equal(t, v, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeUint64(p, v)
-		remaining, value, err = decodeUint64(*p)
+		remaining, value, err = decodeUint64(p.Bytes())
 		p.Reset()
 	})
 	assert.Zero(t, n)
@@ -460,26 +460,26 @@ func TestDecodeInt32(t *testing.T) {
 
 	var value int32
 
-	remaining, value, err := decodeInt32(*p)
+	remaining, value, err := decodeInt32(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeInt32((*p)[1:])
+	_, _, err = decodeInt32((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidInt32)
 
-	remaining, value, err = decodeInt32(*p)
+	remaining, value, err = decodeInt32(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.Equal(t, v, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeInt32(p, v)
-		remaining, value, err = decodeInt32(*p)
+		remaining, value, err = decodeInt32(p.Bytes())
 		p.Reset()
 	})
 	assert.Zero(t, n)
@@ -495,26 +495,26 @@ func TestDecodeInt64(t *testing.T) {
 
 	var value int64
 
-	remaining, value, err := decodeInt64(*p)
+	remaining, value, err := decodeInt64(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeInt64((*p)[1:])
+	_, _, err = decodeInt64((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidInt64)
 
-	remaining, value, err = decodeInt64(*p)
+	remaining, value, err = decodeInt64(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.Equal(t, v, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeInt64(p, v)
-		remaining, value, err = decodeInt64(*p)
+		remaining, value, err = decodeInt64(p.Bytes())
 		p.Reset()
 	})
 	assert.Zero(t, n)
@@ -530,26 +530,26 @@ func TestDecodeFloat32(t *testing.T) {
 
 	var value float32
 
-	remaining, value, err := decodeFloat32(*p)
+	remaining, value, err := decodeFloat32(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeFloat32((*p)[1:])
+	_, _, err = decodeFloat32((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidFloat32)
 
-	remaining, value, err = decodeFloat32(*p)
+	remaining, value, err = decodeFloat32(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.Equal(t, v, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeFloat32(p, v)
-		remaining, value, err = decodeFloat32(*p)
+		remaining, value, err = decodeFloat32(p.Bytes())
 		p.Reset()
 	})
 	assert.Zero(t, n)
@@ -565,26 +565,26 @@ func TestDecodeFloat64(t *testing.T) {
 
 	var value float64
 
-	remaining, value, err := decodeFloat64(*p)
+	remaining, value, err := decodeFloat64(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	_, _, err = decodeFloat64((*p)[1:])
+	_, _, err = decodeFloat64((p.Bytes())[1:])
 	assert.ErrorIs(t, err, InvalidFloat64)
 
-	remaining, value, err = decodeFloat64(*p)
+	remaining, value, err = decodeFloat64(p.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
 	assert.Equal(t, 0, len(remaining))
 
-	(*p)[len(*p)-1] = 'S'
+	(p.Bytes())[len(p.Bytes())-1] = 'S'
 	assert.Equal(t, v, value)
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		encodeFloat64(p, v)
-		remaining, value, err = decodeFloat64(*p)
+		remaining, value, err = decodeFloat64(p.Bytes())
 		p.Reset()
 	})
 	assert.Zero(t, n)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -28,7 +28,7 @@ func TestDecoderNil(t *testing.T) {
 	p := NewBuffer()
 	Encoder(p).Nil()
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value := d.Nil()
 	assert.True(t, value)
 
@@ -40,7 +40,7 @@ func TestDecoderNil(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Nil()
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value = d.Nil()
 		d.Return()
 		p.Reset()
@@ -62,7 +62,7 @@ func TestDecoderMap(t *testing.T) {
 		e.String(k).Uint32(v)
 	}
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	size, err := d.Map(StringKind, Uint32Kind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(len(m)), size)
@@ -91,7 +91,7 @@ func TestDecoderMap(t *testing.T) {
 		for k, v = range m {
 			e.String(k).Uint32(v)
 		}
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		size, err = d.Map(StringKind, Uint32Kind)
 		for i := uint32(0); i < size; i++ {
 			_, _ = d.String()
@@ -114,7 +114,7 @@ func TestDecoderSlice(t *testing.T) {
 		e.String(v)
 	}
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	size, err := d.Slice(StringKind)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(len(m)), size)
@@ -139,7 +139,7 @@ func TestDecoderSlice(t *testing.T) {
 		for _, v := range m {
 			e.String(v)
 		}
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		size, err = d.Slice(StringKind)
 		for i := uint32(0); i < size; i++ {
 			_, _ = d.String()
@@ -158,7 +158,7 @@ func TestDecoderBytes(t *testing.T) {
 
 	Encoder(p).Bytes(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Bytes(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -171,7 +171,7 @@ func TestDecoderBytes(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Bytes(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Bytes(value)
 		d.Return()
 		p.Reset()
@@ -187,7 +187,7 @@ func TestDecoderString(t *testing.T) {
 
 	Encoder(p).String(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.String()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -200,7 +200,7 @@ func TestDecoderString(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).String(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.String()
 		d.Return()
 		p.Reset()
@@ -216,7 +216,7 @@ func TestDecoderError(t *testing.T) {
 
 	Encoder(p).Error(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Error()
 	assert.NoError(t, err)
 	assert.ErrorIs(t, value, v)
@@ -229,7 +229,7 @@ func TestDecoderError(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Error(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Error()
 		d.Return()
 		p.Reset()
@@ -243,7 +243,7 @@ func TestDecoderBool(t *testing.T) {
 	p := NewBuffer()
 	Encoder(p).Bool(true)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Bool()
 	assert.NoError(t, err)
 	assert.True(t, value)
@@ -256,7 +256,7 @@ func TestDecoderBool(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Bool(true)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Bool()
 		d.Return()
 		p.Reset()
@@ -272,7 +272,7 @@ func TestDecoderUint8(t *testing.T) {
 
 	Encoder(p).Uint8(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Uint8()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -285,7 +285,7 @@ func TestDecoderUint8(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Uint8(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Uint8()
 		d.Return()
 		p.Reset()
@@ -301,7 +301,7 @@ func TestDecoderUint16(t *testing.T) {
 
 	Encoder(p).Uint16(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Uint16()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -314,7 +314,7 @@ func TestDecoderUint16(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Uint16(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Uint16()
 		d.Return()
 		p.Reset()
@@ -330,7 +330,7 @@ func TestDecoderUint32(t *testing.T) {
 
 	Encoder(p).Uint32(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Uint32()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -343,7 +343,7 @@ func TestDecoderUint32(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Uint32(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Uint32()
 		d.Return()
 		p.Reset()
@@ -359,7 +359,7 @@ func TestDecoderUint64(t *testing.T) {
 
 	Encoder(p).Uint64(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Uint64()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -372,7 +372,7 @@ func TestDecoderUint64(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Uint64(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Uint64()
 		d.Return()
 		p.Reset()
@@ -388,7 +388,7 @@ func TestDecoderInt32(t *testing.T) {
 
 	Encoder(p).Int32(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Int32()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -401,7 +401,7 @@ func TestDecoderInt32(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Int32(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Int32()
 		d.Return()
 		p.Reset()
@@ -417,7 +417,7 @@ func TestDecoderInt64(t *testing.T) {
 
 	Encoder(p).Int64(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Int64()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -430,7 +430,7 @@ func TestDecoderInt64(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Int64(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Int64()
 		d.Return()
 		p.Reset()
@@ -446,7 +446,7 @@ func TestDecoderFloat32(t *testing.T) {
 
 	Encoder(p).Float32(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Float32()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -459,7 +459,7 @@ func TestDecoderFloat32(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Float32(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Float32()
 		d.Return()
 		p.Reset()
@@ -475,7 +475,7 @@ func TestDecoderFloat64(t *testing.T) {
 
 	Encoder(p).Float64(v)
 
-	d := GetDecoder(*p)
+	d := GetDecoder(p.Bytes())
 	value, err := d.Float64()
 	assert.NoError(t, err)
 	assert.Equal(t, v, value)
@@ -488,7 +488,7 @@ func TestDecoderFloat64(t *testing.T) {
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
 		Encoder(p).Float64(v)
-		d = GetDecoder(*p)
+		d = GetDecoder(p.Bytes())
 		value, err = d.Float64()
 		d.Return()
 		p.Reset()

--- a/encode_test.go
+++ b/encode_test.go
@@ -29,8 +29,8 @@ func TestEncodeNil(t *testing.T) {
 	p := NewBuffer()
 	encodeNil(p)
 
-	assert.Equal(t, 1, len(*p))
-	assert.Equal(t, NilKind, Kind(*p))
+	assert.Equal(t, 1, len(p.Bytes()))
+	assert.Equal(t, NilKind, Kind(p.Bytes()))
 
 	n := testing.AllocsPerRun(100, func() {
 		encodeNil(p)
@@ -45,11 +45,11 @@ func TestEncodeMap(t *testing.T) {
 	p := NewBuffer()
 	encodeMap(p, 32, StringKind, Uint32Kind)
 
-	assert.Equal(t, 1+1+1+1+4, len(*p))
-	assert.Equal(t, MapKind, Kind((*p)[0:1]))
-	assert.Equal(t, StringKind, Kind((*p)[1:2]))
-	assert.Equal(t, Uint32Kind, Kind((*p)[2:3]))
-	assert.Equal(t, Uint32Kind, Kind((*p)[3:4]))
+	assert.Equal(t, 1+1+1+1+4, len(p.Bytes()))
+	assert.Equal(t, MapKind, Kind((p.Bytes())[0:1]))
+	assert.Equal(t, StringKind, Kind((p.Bytes())[1:2]))
+	assert.Equal(t, Uint32Kind, Kind((p.Bytes())[2:3]))
+	assert.Equal(t, Uint32Kind, Kind((p.Bytes())[3:4]))
 
 	n := testing.AllocsPerRun(100, func() {
 		encodeMap(p, 32, StringKind, Uint32Kind)
@@ -64,10 +64,10 @@ func TestEncodeSlice(t *testing.T) {
 	p := NewBuffer()
 	encodeSlice(p, 32, StringKind)
 
-	assert.Equal(t, 1+1+1+4, len(*p))
-	assert.Equal(t, SliceKind, Kind((*p)[0:1]))
-	assert.Equal(t, StringKind, Kind((*p)[1:2]))
-	assert.Equal(t, Uint32Kind, Kind((*p)[2:3]))
+	assert.Equal(t, 1+1+1+4, len(p.Bytes()))
+	assert.Equal(t, SliceKind, Kind((p.Bytes())[0:1]))
+	assert.Equal(t, StringKind, Kind((p.Bytes())[1:2]))
+	assert.Equal(t, Uint32Kind, Kind((p.Bytes())[2:3]))
 
 	n := testing.AllocsPerRun(100, func() {
 		encodeSlice(p, 32, StringKind)
@@ -84,8 +84,8 @@ func TestEncodeBytes(t *testing.T) {
 
 	encodeBytes(p, v)
 
-	assert.Equal(t, 1+1+4+len(v), len(*p))
-	assert.Equal(t, (Buffer)(v), (*p)[1+1+4:])
+	assert.Equal(t, 1+1+4+len(v), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(v), (p.Bytes())[1+1+4:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -104,8 +104,8 @@ func TestEncodeString(t *testing.T) {
 
 	encodeString(p, v)
 
-	assert.Equal(t, 1+1+4+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1+1+4:])
+	assert.Equal(t, 1+1+4+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1+1+4:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -124,8 +124,8 @@ func TestEncodeError(t *testing.T) {
 
 	encodeError(p, v)
 
-	assert.Equal(t, 1+1+1+4+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1+1+1+4:])
+	assert.Equal(t, 1+1+1+4+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1+1+1+4:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -143,8 +143,8 @@ func TestEncodeBool(t *testing.T) {
 
 	encodeBool(p, true)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -163,8 +163,8 @@ func TestEncodeUint8(t *testing.T) {
 
 	encodeUint8(p, v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -183,8 +183,8 @@ func TestEncodeUint16(t *testing.T) {
 
 	encodeUint16(p, v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -203,8 +203,8 @@ func TestEncodeUint32(t *testing.T) {
 
 	encodeUint32(p, v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -223,8 +223,8 @@ func TestEncodeUint64(t *testing.T) {
 
 	encodeUint64(p, v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -243,8 +243,8 @@ func TestEncodeInt32(t *testing.T) {
 
 	encodeInt32(p, v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -263,8 +263,8 @@ func TestEncodeInt64(t *testing.T) {
 
 	encodeInt64(p, v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -283,8 +283,8 @@ func TestEncodeFloat32(t *testing.T) {
 
 	encodeFloat32(p, v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -303,8 +303,8 @@ func TestEncodeFloat64(t *testing.T) {
 
 	encodeFloat64(p, v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -30,8 +30,8 @@ func TestEncoderNil(t *testing.T) {
 
 	Encoder(p).Nil()
 
-	assert.Equal(t, 1, len(*p))
-	assert.Equal(t, NilKind, Kind(*p))
+	assert.Equal(t, 1, len(p.Bytes()))
+	assert.Equal(t, NilKind, Kind(p.Bytes()))
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -55,7 +55,7 @@ func TestEncoderMap(t *testing.T) {
 		e.String(k).Uint32(v)
 	}
 
-	assert.Equal(t, 1+1+1+1+4+len(m)*(1+1+4+1+1+4), len(*p))
+	assert.Equal(t, 1+1+1+1+4+len(m)*(1+1+4+1+1+4), len(p.Bytes()))
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -82,7 +82,7 @@ func TestEncoderSlice(t *testing.T) {
 		e.String(k).Uint32(v)
 	}
 
-	assert.Equal(t, 1+1+1+1+4+len(m)*(1+1+4+1+1+4), len(*p))
+	assert.Equal(t, 1+1+1+1+4+len(m)*(1+1+4+1+1+4), len(p.Bytes()))
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -103,8 +103,8 @@ func TestEncoderBytes(t *testing.T) {
 
 	Encoder(p).Bytes(v)
 
-	assert.Equal(t, 1+1+4+len(v), len(*p))
-	assert.Equal(t, (Buffer)(v), (*p)[1+1+4:])
+	assert.Equal(t, 1+1+4+len(v), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(v), (p.Bytes())[1+1+4:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -123,8 +123,8 @@ func TestEncoderString(t *testing.T) {
 
 	Encoder(p).String(v)
 
-	assert.Equal(t, 1+1+4+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1+1+4:])
+	assert.Equal(t, 1+1+4+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1+1+4:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -143,8 +143,8 @@ func TestEncoderError(t *testing.T) {
 
 	Encoder(p).Error(v)
 
-	assert.Equal(t, 1+1+1+4+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1+1+1+4:])
+	assert.Equal(t, 1+1+1+4+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1+1+1+4:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -162,8 +162,8 @@ func TestEncoderBool(t *testing.T) {
 
 	Encoder(p).Bool(true)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -182,8 +182,8 @@ func TestEncoderUint8(t *testing.T) {
 
 	Encoder(p).Uint8(v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -202,8 +202,8 @@ func TestEncoderUint16(t *testing.T) {
 
 	Encoder(p).Uint16(v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -222,8 +222,8 @@ func TestEncoderUint32(t *testing.T) {
 
 	Encoder(p).Uint32(v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -242,8 +242,8 @@ func TestEncoderUint64(t *testing.T) {
 
 	Encoder(p).Uint64(v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -262,8 +262,8 @@ func TestEncoderInt32(t *testing.T) {
 
 	Encoder(p).Int32(v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -282,8 +282,8 @@ func TestEncoderInt64(t *testing.T) {
 
 	Encoder(p).Int64(v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -302,8 +302,8 @@ func TestEncoderFloat32(t *testing.T) {
 
 	Encoder(p).Float32(v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {
@@ -322,8 +322,8 @@ func TestEncoderFloat64(t *testing.T) {
 
 	Encoder(p).Float64(v)
 
-	assert.Equal(t, 1+len(e), len(*p))
-	assert.Equal(t, (Buffer)(e), (*p)[1:])
+	assert.Equal(t, 1+len(e), len(p.Bytes()))
+	assert.Equal(t, (Buffer)(e), (p.Bytes())[1:])
 
 	p.Reset()
 	n := testing.AllocsPerRun(100, func() {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 const (
-	Version = "v0.3.1"
+	Version = "0.4.0"
 )


### PR DESCRIPTION
## Description
Adds a helper function for getting a byte slice from a polyglot buffer
Adds a helper function for getting the byte length of a polyglot buffer
Also configures a GitHub action to update the polyglot version automatically from git tags.

Fixes #3 
Fixes #4 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']


## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
