### PR TITLE
fix: Encode `nil` maps consistently

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 const (
-	Version = "0.5.1"
+	Version = "0.5.2"
 )

--- a/templates/encodeMap.templ
+++ b/templates/encodeMap.templ
@@ -1,10 +1,11 @@
 {{define "encodeMap"}}
     func (x {{ CamelCase .FullName }}Map) Encode (b *polyglot.Buffer) {
+        {{ $keyKind := GetKind .MapKey.Kind -}}
+        {{ $valKind := GetKind .MapValue.Kind -}}
+        
         if x == nil {
-            polyglot.Encoder(b).Nil()
-        } else {
-            {{ $keyKind := GetKind .MapKey.Kind -}}
-            {{ $valKind := GetKind .MapValue.Kind -}}
+            polyglot.Encoder(b).Map(0, {{$keyKind}}, {{$valKind}})
+        } else { 
             polyglot.Encoder(b).Map(uint32(len(x)), {{$keyKind}}, {{$valKind}})
             for k, v := range x {
                 {{ $keyEncoder := GetLUTEncoder .MapKey.Kind -}}


### PR DESCRIPTION
## Description

Fixes https://linear.app/loopholelabs/issue/LOOP-46/encode-nil-maps-consistently-across-polyglot-implementations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

See [PR in https://github.com/loopholelabs/polyglot-test-data](https://github.com/loopholelabs/polyglot-test-data/pull/1)

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
